### PR TITLE
Fixed the path for Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ author:
   bio: Evangelist on the Loose
   email_md5: 0d3794fe37746ea54926ca6878712721
 
-permalink: /:title/index.html
+permalink: /:title/
 
 gems: ["jekyll-paginate"]
 

--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ github_repo_url: https://github.com/johnpapa/johnpapa.github.io/
 
 rss_path: feed.xml
 rss_url: http://feeds.feedburner.com/johnpapa
-categories_path: categories.html
+categories_path: categories/
 #tags_path: tags.html
 
 BASE_PATH:

--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ author:
   bio: Evangelist on the Loose
   email_md5: 0d3794fe37746ea54926ca6878712721
 
-permalink: /:title
+permalink: /:title/index.html
 
 gems: ["jekyll-paginate"]
 

--- a/_includes/default.html
+++ b/_includes/default.html
@@ -23,7 +23,7 @@
     <link href="{{ site.BASE_PATH }}/assets/resources/syntax/syntax.css" rel="stylesheet">
     <link href="{{ site.BASE_PATH }}/assets/css/style.css" rel="stylesheet">
 
-    <link rel="shortcut icon" type="image/x-icon" href="{{ site.BASE_PATH }}assets/ico/favicon.ico">
+	<link rel="shortcut icon" type="image/x-icon" href="{{ site.BASE_PATH}}/assets/ico/favicon.ico">
 
     <!-- Le fav and touch icons -->
     <!-- Update these with your own images


### PR DESCRIPTION
## What changed:

- Changes made in jekyll config.yml to generate new path
   
    ```
    // old
    <project_root>/_site/<post-name>.html`
    // old link
    johnpapa.net/<post-name>
    ```
    ```
// New
  <project_root>/_site/<post-name/index.html`
// new link
 johnpapa.net/<post-name>/
    ```

## How to test

```
git clone https://github.com/chintan-patel/johnpapa.github.io.git
cd johnpapa.github.io
git checkout fix/jekyll-path
bundle install
jekyll serve
```

## What to check

- Verify if the files and folders are generated correctly.
- All URL link works fine in site.
- `favicon.ico` is loading for all the post pages